### PR TITLE
Install wget with ssl support prior to the build

### DIFF
--- a/2.0.0-RC1/Dockerfile
+++ b/2.0.0-RC1/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC1
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0-RC2/Dockerfile
+++ b/2.0.0-RC2/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC2
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0-RC3/Dockerfile
+++ b/2.0.0-RC3/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC3
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0-RC4/Dockerfile
+++ b/2.0.0-RC4/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC4
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0-RC5/Dockerfile
+++ b/2.0.0-RC5/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC5
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0-RC6/Dockerfile
+++ b/2.0.0-RC6/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0-RC6
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.0/Dockerfile
+++ b/2.0.0/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.0
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.1/Dockerfile
+++ b/2.0.1/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.1
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.2/Dockerfile
+++ b/2.0.2/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.2
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.0.3/Dockerfile
+++ b/2.0.3/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.0.3
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts/$GATLING_VERSION/gatling-charts-highcharts-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.0/Dockerfile
+++ b/2.1.0/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.0
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.1/Dockerfile
+++ b/2.1.1/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.1
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.2/Dockerfile
+++ b/2.1.2/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.2
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.3/Dockerfile
+++ b/2.1.3/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.3
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.4/Dockerfile
+++ b/2.1.4/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.4
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.5/Dockerfile
+++ b/2.1.5/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.5
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.6/Dockerfile
+++ b/2.1.6/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.6
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.1.7/Dockerfile
+++ b/2.1.7/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.1.7
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.2.0-M1/Dockerfile
+++ b/2.2.0-M1/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.2.0-M1
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.2.0-M2/Dockerfile
+++ b/2.2.0-M2/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.2.0-M2
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.2.0-M3/Dockerfile
+++ b/2.2.0-M3/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.2.0-M3
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.2.0/Dockerfile
+++ b/2.2.0/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.2.0
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \

--- a/2.2.1/Dockerfile
+++ b/2.2.1/Dockerfile
@@ -17,7 +17,8 @@ ENV GATLING_VERSION 2.2.1
 RUN mkdir -p gatling
 
 # install gatling
-RUN mkdir -p /tmp/downloads && \
+RUN apk add --update wget && \
+  mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \


### PR DESCRIPTION
Fixes the following build error:

```bash
wget: can't execute 'ssl_helper': No such file or directory
wget: error getting response: Connection reset by peer
```