### PR TITLE
Add support for gatling 3.0

### DIFF
--- a/3.0.0-RC4/Dockerfile
+++ b/3.0.0-RC4/Dockerfile
@@ -1,0 +1,42 @@
+# Gatling is a highly capable load testing tool.
+#
+# Documentation: https://gatling.io/docs/2.3/
+# Cheat sheet: http://gatling.io/#/cheat-sheet/2.3
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER Denis Vazhenin <denis.vazhenin@me.com>
+
+# working directory for gatling
+WORKDIR /opt
+
+# gating version
+ENV GATLING_VERSION 3.0.0-RC4
+
+# add compatibility libraries for librcrypto.so
+RUN apk add libc6-compat
+
+# create directory for gatling install
+RUN mkdir -p gatling
+
+# install gatling
+RUN apk add --update wget bash && \
+  mkdir -p /tmp/downloads && \
+  wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
+  https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
+  mkdir -p /tmp/archive && cd /tmp/archive && \
+  unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
+  mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
+  rm -rf /tmp/*
+
+# change context to gatling directory
+WORKDIR  /opt/gatling
+
+# set directories below to be mountable from host
+VOLUME ["/opt/gatling/conf", "/opt/gatling/results", "/opt/gatling/user-files"]
+
+# set environment variables
+ENV PATH /opt/gatling/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GATLING_HOME /opt/gatling
+
+ENTRYPOINT ["gatling.sh"]

--- a/3.0.0/Dockerfile
+++ b/3.0.0/Dockerfile
@@ -11,16 +11,13 @@ MAINTAINER Denis Vazhenin <denis.vazhenin@me.com>
 WORKDIR /opt
 
 # gating version
-ENV GATLING_VERSION 3.0.0-RC4
-
-# add compatibility libraries for librcrypto.so
-RUN apk add libc6-compat
+ENV GATLING_VERSION 3.0.0
 
 # create directory for gatling install
 RUN mkdir -p gatling
 
 # install gatling
-RUN apk add --update wget bash && \
+RUN apk add --update wget bash libc6-compat && \
   mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \

--- a/3.0.0/Dockerfile
+++ b/3.0.0/Dockerfile
@@ -1,7 +1,7 @@
 # Gatling is a highly capable load testing tool.
 #
-# Documentation: https://gatling.io/docs/2.3/
-# Cheat sheet: http://gatling.io/#/cheat-sheet/2.3
+# Documentation: https://gatling.io/docs/3.0/
+# Cheat sheet: https://gatling.io/docs/3.0/cheat-sheet/
 
 FROM openjdk:8-jdk-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-2.3.1/Dockerfile
+3.0.0/Dockerfile

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 * 2.2.4
 * 2.2.5
 * 2.3.0
-* 2.3.1 (latest)
+* 2.3.1
+* 3.0.0 (latest)
 
 [![CircleCI](https://circleci.com/gh/denvazh/gatling/tree/master.svg?style=svg)](https://circleci.com/gh/denvazh/gatling/tree/master)
 [![](https://images.microbadger.com/badges/image/denvazh/gatling.svg)](http://microbadger.com/images/denvazh/gatling "Get your own image badge on microbadger.com")


### PR DESCRIPTION
First of all, thanks for you awesome work.

Recently I updated my tests to gatling 3.0 and to still use them with your image i needed those changes. Hopefully they will be useful for others :)

libc6-compat is required since gatling tries to load libnetty, which fails, because there is no libcrypt.so.1 in the system