### PR TITLE
Add gatling 3.3.1, run as uid 1000, gid 1000 (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+local.Dockerfile
+gatling-charts-highcharts-bundle-3.3.1-bundle.zip

--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -1,0 +1,36 @@
+# Gatling is a highly capable load testing tool.
+#
+# Documentation: https://gatling.io/docs/3.3/
+# Cheat sheet: https://gatling.io/docs/3.3/cheat-sheet/
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER Denis Vazhenin <denis.vazhenin@me.com>
+
+RUN apk add --update wget bash libc6-compat
+
+# gatling version
+ENV GATLING_VERSION 3.3.1
+
+# gatling user
+RUN addgroup -S gatling -g 1000 && adduser -S gatling -G gatling -u 1000
+USER gatling
+RUN mkdir /home/gatling/gatling
+
+# gatling home
+ENV GATLING_HOME /home/gatling/gatling
+WORKDIR  $GATLING_HOME
+
+# install gatling
+RUN mkdir -p /tmp/downloads && \
+    wget --show-progress --progress=bar:force -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip
+RUN mkdir -p /tmp/archive && \
+    unzip /tmp/downloads/gatling-$GATLING_VERSION.zip -d /tmp/archive && \
+    mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* $GATLING_HOME/ && \
+    rm -rf /tmp/*
+ENV PATH $GATLING_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# set directories below to be mountable from host
+VOLUME ["$GATLING_HOME/conf", "$GATLING_HOME/results", "$GATLING_HOME/user-files"]
+
+ENTRYPOINT ["gatling.sh"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker run -it --rm denvazh/gatling
 ```
 
 Mount configuration and simulation files from the host machine and run gatling in interactive mode
-
+> Make sure the /home/core/gatling/results path exists firstly, otherwise it will suffer write permission issue, because the non-existed host volume will be created as root permission
 ```
 docker run -it --rm -v /home/core/gatling/conf:/opt/gatling/conf \
 -v /home/core/gatling/user-files:/opt/gatling/user-files \

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ docker run -it --rm denvazh/gatling
 Mount configuration and simulation files from the host machine and run gatling in interactive mode
 > Make sure the /home/core/gatling/results path exists firstly, otherwise it will suffer write permission issue, because the non-existed host volume will be created as root permission
 ```
-docker run -it --rm -v /home/core/gatling/conf:/opt/gatling/conf \
--v /home/core/gatling/user-files:/opt/gatling/user-files \
--v /home/core/gatling/results:/opt/gatling/results \
+docker run -it --rm -v /home/core/gatling/conf:/home/gatling/gatling/conf \
+-v /home/core/gatling/user-files:/home/gatling/gatling/user-files \
+-v /home/core/gatling/results:/home/gatling/gatling/results \
 denvazh/gatling
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@
 * 3.1.2
 * 3.1.3
 * 3.2.0
-* 3.2.1 (latest)
+* 3.2.1
+* 3.3.1 (latest)
 
 [![CircleCI](https://circleci.com/gh/denvazh/gatling/tree/master.svg?style=svg)](https://circleci.com/gh/denvazh/gatling/tree/master)
 [![](https://images.microbadger.com/badges/image/denvazh/gatling.svg)](http://microbadger.com/images/denvazh/gatling "Get your own image badge on microbadger.com")


### PR DESCRIPTION
At GoCD pipeline, it will run `git clean -dffx` firstly. But perviously gatilng image run as root user, it will cause Error when git clean repo.