### PR TITLE
Added 3.4.1 version and parametrized gatling version on build

### DIFF
--- a/3.4.1/Dockerfile
+++ b/3.4.1/Dockerfile
@@ -1,0 +1,41 @@
+# Gatling is a highly capable load testing tool.
+#
+# Documentation: https://gatling.io/docs/3.2/
+# Cheat sheet: https://gatling.io/docs/3.2/cheat-sheet/
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER Denis Vazhenin <denis.vazhenin@me.com>
+
+# working directory for gatling
+WORKDIR /opt
+
+ARG gatling_version=3.4.1
+
+# gatling version
+ENV GATLING_VERSION=$gatling_version
+
+# create directory for gatling install
+RUN mkdir -p gatling
+
+# install gatling
+RUN apk add --update wget bash libc6-compat && \
+  mkdir -p /tmp/downloads && \
+  wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
+  https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
+  mkdir -p /tmp/archive && cd /tmp/archive && \
+  unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
+  mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
+  rm -rf /tmp/*
+
+# change context to gatling directory
+WORKDIR  /opt/gatling
+
+# set directories below to be mountable from host
+VOLUME ["/opt/gatling/conf", "/opt/gatling/results", "/opt/gatling/user-files"]
+
+# set environment variables
+ENV PATH /opt/gatling/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GATLING_HOME /opt/gatling
+
+ENTRYPOINT ["gatling.sh"]

--- a/README.md
+++ b/README.md
@@ -4,57 +4,7 @@
 
 # Docker Tags
 
-* 2.0.0-RC1
-* 2.0.0-RC2
-* 2.0.0-RC3
-* 2.0.0-RC4
-* 2.0.0-RC5
-* 2.0.0-RC6
-* 2.0.0
-* 2.0.1
-* 2.0.2
-* 2.0.3
-* 2.1.0
-* 2.1.1
-* 2.1.2
-* 2.1.3
-* 2.1.4
-* 2.1.5
-* 2.1.6
-* 2.1.7
-* 2.2.0-M1
-* 2.2.0-M2
-* 2.2.0-M2
-* 2.2.0
-* 2.2.1
-* 2.2.2
-* 2.2.3
-* 2.2.4
-* 2.2.5
-* 2.3.0
-* 2.3.1
-* 3.0.0-RC1
-* 3.0.0-RC2
-* 3.0.0-RC3
-* 3.0.0-RC4
-* 3.0.0
-* 3.0.1
-* 3.0.1.1
-* 3.0.2
-* 3.0.3
-* 3.1.0
-* 3.1.0.1
-* 3.1.1
-* 3.1.2
-* 3.1.3
-* 3.2.0
-* 3.2.1
 * 3.4.1 (latest)
-
-[![CircleCI](https://circleci.com/gh/denvazh/gatling/tree/master.svg?style=svg)](https://circleci.com/gh/denvazh/gatling/tree/master)
-[![](https://images.microbadger.com/badges/image/denvazh/gatling.svg)](http://microbadger.com/images/denvazh/gatling "Get your own image badge on microbadger.com")
-
-Note: Gatling versions from 2.1.0 to 2.2.5 are built with Scala 2.11, versions from 2.3.0 onwards are built with Scala 2.12.
 
 # Installation
 
@@ -64,24 +14,24 @@ Note: Gatling versions from 2.1.0 to 2.2.5 are built with Scala 2.11, versions f
 
 Latest version:
 
-`docker pull denvazh/gatling:latest`
+`docker pull axelbergh/gatling:latest`
 
 All versions:
 
-`docker pull denvazh/gatling`
+`docker pull axelbergh/gatling`
 
 Specific version:
 
-`docker pull denvazh/gatling:3.2.1`
+`docker pull axelbergh/gatling:3.2.1`
 
-* [Alternatively] Build an image from Dockerfile: `docker build -t="denvazh/gatling" github.com/denvazh/gatling`
+* [Alternatively] Build an image from Dockerfile: `docker build -t="axelbergh/gatling" github.com/axelbergh/gatling`
 
 # Usage
 
 Use image to run container
 
 ```
-docker run -it --rm denvazh/gatling
+docker run -it --rm axelbergh/gatling
 ```
 
 Mount configuration and simulation files from the host machine and run gatling in interactive mode
@@ -90,17 +40,17 @@ Mount configuration and simulation files from the host machine and run gatling i
 docker run -it --rm -v /home/core/gatling/conf:/opt/gatling/conf \
 -v /home/core/gatling/user-files:/opt/gatling/user-files \
 -v /home/core/gatling/results:/opt/gatling/results \
-denvazh/gatling
+axelbergh/gatling
 ```
 
 Use the `-e` switch to use JAVA_OPTS to pass parameters to gatling tests
 
 ```
-docker run -e JAVA_OPTS="-Dusers=10" -it --rm denvazh/gatling
+docker run -e JAVA_OPTS="-Dusers=10" -it --rm axelbergh/gatling
 ```
 
 Use `--build-arg gatling_version=<gatling version>` on build to override gatling bundle version
 
 ```
-docker build --build-arg gatling_version=3.4.1 github.com/denvazh/gatling
+docker build --build-arg gatling_version=3.4.1 github.com/axelbergh/gatling
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@
 * 3.1.2
 * 3.1.3
 * 3.2.0
-* 3.2.1 (latest)
+* 3.2.1
+* 3.4.1 (latest)
 
 [![CircleCI](https://circleci.com/gh/denvazh/gatling/tree/master.svg?style=svg)](https://circleci.com/gh/denvazh/gatling/tree/master)
 [![](https://images.microbadger.com/badges/image/denvazh/gatling.svg)](http://microbadger.com/images/denvazh/gatling "Get your own image badge on microbadger.com")
@@ -96,4 +97,10 @@ Use the `-e` switch to use JAVA_OPTS to pass parameters to gatling tests
 
 ```
 docker run -e JAVA_OPTS="-Dusers=10" -it --rm denvazh/gatling
+```
+
+Use `--build-arg gatling_version=<gatling version>` on build to override gatling bundle version
+
+```
+docker build --build-arg gatling_version=3.4.1 github.com/denvazh/gatling
 ```


### PR DESCRIPTION
Added on Dockerfile:
```
ARG gatling_version=3.4.1

# gatling version
ENV GATLING_VERSION=$gatling_version
```
to be able to override gatling version on docker build:
```
docker build --build-arg gatling_version=3.4.1 github.com/denvazh/gatling
```
See [this post](https://vsupalov.com/docker-build-pass-environment-variables/)